### PR TITLE
Support multiple inputs for extensions and languages in the backend

### DIFF
--- a/crates/book-searcher-core/src/search/query.rs
+++ b/crates/book-searcher-core/src/search/query.rs
@@ -121,9 +121,9 @@ impl SearchQuery {
         }
 
         if let Some(query) = new_bool_query(queries, self.mode) {
-            return Ok(Box::new(query));
+            Ok(Box::new(query))
         } else {
-            return Err(QueryParserError::AllButQueryForbidden);
+            Err(QueryParserError::AllButQueryForbidden)
         }
     }
 }

--- a/crates/book-searcher-core/src/search/query.rs
+++ b/crates/book-searcher-core/src/search/query.rs
@@ -7,7 +7,7 @@ use tantivy::{
     Term,
 };
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Copy, Debug, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum SearchMode {
     Filter,
@@ -85,17 +85,25 @@ impl SearchQuery {
         }
 
         if let Some(ref extension) = self.extension {
-            let term =
-                Term::from_field_text(searcher.extension, extension.to_ascii_lowercase().trim());
-            let query = TermQuery::new(term, IndexRecordOption::Basic);
-            queries.push(Box::new(query));
+            let terms = get_positions_and_terms(
+                searcher.extension,
+                extension.to_ascii_lowercase().trim(),
+                &mut tokenizer,
+            );
+            if let Some(query) = new_terms_query(terms, SearchMode::Explore) {
+                queries.push(query);
+            }
         }
 
         if let Some(ref language) = self.language {
-            let term =
-                Term::from_field_text(searcher.language, language.to_ascii_lowercase().trim());
-            let query = TermQuery::new(term, IndexRecordOption::WithFreqsAndPositions);
-            queries.push(Box::new(query));
+            let terms = get_positions_and_terms(
+                searcher.language,
+                language.to_ascii_lowercase().trim(),
+                &mut tokenizer,
+            );
+            if let Some(query) = new_terms_query(terms, SearchMode::Explore) {
+                queries.push(query);
+            }
         }
 
         if let Some(ref isbn) = self.isbn {
@@ -112,16 +120,11 @@ impl SearchQuery {
             }
         }
 
-        let query = match self.mode {
-            SearchMode::Filter => {
-                BooleanQuery::new(queries.into_iter().map(|q| (Occur::Must, q)).collect())
-            }
-            SearchMode::Explore => {
-                BooleanQuery::new(queries.into_iter().map(|q| (Occur::Should, q)).collect())
-            }
-        };
-
-        Ok(Box::new(query))
+        if let Some(query) = new_bool_query(queries, self.mode) {
+            return Ok(Box::new(query));
+        } else {
+            return Err(QueryParserError::AllButQueryForbidden);
+        }
     }
 }
 
@@ -163,4 +166,40 @@ pub(crate) fn phrase_or_term_query(terms: Vec<(usize, Term)>) -> Option<Box<dyn 
             IndexRecordOption::WithFreqsAndPositions,
         ))
     })
+}
+
+pub(crate) fn new_bool_query(
+    queries: Vec<Box<dyn Query>>,
+    mode: SearchMode,
+) -> Option<Box<dyn Query>> {
+    if queries.is_empty() {
+        return None;
+    }
+
+    let query = match mode {
+        SearchMode::Filter => {
+            BooleanQuery::new(queries.into_iter().map(|q| (Occur::Must, q)).collect())
+        }
+        SearchMode::Explore => {
+            BooleanQuery::new(queries.into_iter().map(|q| (Occur::Should, q)).collect())
+        }
+    };
+
+    Some(Box::new(query))
+}
+
+pub(crate) fn new_terms_query(
+    terms: Vec<(usize, Term)>,
+    mode: SearchMode,
+) -> Option<Box<dyn Query>> {
+    if terms.is_empty() {
+        return None;
+    }
+
+    let queries = terms
+        .into_iter()
+        .map(|(_, term)| Box::new(TermQuery::new(term, IndexRecordOption::Basic)) as Box<dyn Query>)
+        .collect();
+
+    new_bool_query(queries, mode)
 }

--- a/crates/book-searcher/src/main.rs
+++ b/crates/book-searcher/src/main.rs
@@ -116,7 +116,7 @@ fn main() {
 
 #[actix_web::main]
 async fn run(opts: Run) -> std::io::Result<()> {
-    info!("book-searcher webserver started: {}", opts.bind);
+    info!("Webserver started: http://{}", opts.bind);
 
     let index_dir = std::env::current_exe()
         .unwrap()


### PR DESCRIPTION
To solve #149, this PR implements support for multiple inputs of extension and langage in the backend to facilitate subsequent modifications to the frontend.