### PR TITLE
fix: responsive styles for detail card title section

### DIFF
--- a/frontend/src/components/BookDetailCard.tsx
+++ b/frontend/src/components/BookDetailCard.tsx
@@ -80,13 +80,34 @@ const BookDetailView: React.FC<BookDetailViewProps> = ({ book }) => {
         variant="outline"
       >
         <CardHeader>
-          <Flex align="flex-start" flexDirection={{base: 'column', lg: "row"}} justify="space-between" gap={{base: "4", lg: "2"}}>
-            <Heading as="h3" fontSize={['xl', '2xl', '2xl']} whiteSpace='break-spaces' flexShrink={0} flex={1} minW="0">
+          <Flex
+            align="flex-start"
+            flexDirection={{ base: 'column', lg: 'row' }}
+            justify="space-between"
+            gap={{ base: '4', lg: '2' }}
+          >
+            <Heading
+              as="h3"
+              fontSize={['xl', '2xl', '2xl']}
+              whiteSpace="break-spaces"
+              flexShrink={0}
+              flex={1}
+              minW="0"
+            >
               <Text>{title}</Text>
             </Heading>
-            <Flex gap="2" flexDirection={{base: 'column', sm: "row"}}  w={{base: "100%", sm: 'auto'}}>
+            <Flex
+              gap="2"
+              flexDirection={{ base: 'column', sm: 'row' }}
+              w={{ base: '100%', sm: 'auto' }}
+            >
               {md5 != undefined && md5.length > 0 ? (
-                <Button as={ExternalLink} minWidth='unset' w={{base: "100%", sm: 'auto'}} href={import.meta.env.VITE_MD5_BASE_URL + md5}>
+                <Button
+                  as={ExternalLink}
+                  minWidth="unset"
+                  w={{ base: '100%', sm: 'auto' }}
+                  href={import.meta.env.VITE_MD5_BASE_URL + md5}
+                >
                   {t('table.redirect2aa')}
                 </Button>
               ) : null}
@@ -94,7 +115,9 @@ const BookDetailView: React.FC<BookDetailViewProps> = ({ book }) => {
               ipfs_cid != undefined &&
               ipfs_cid.length > 0 &&
               rootContext.ipfsGateways.length > 0 ? (
-                <Button onClick={onOpen} w={{base: "100%", sm: 'auto'}}>{t('table.preview')}</Button>
+                <Button onClick={onOpen} w={{ base: '100%', sm: 'auto' }}>
+                  {t('table.preview')}
+                </Button>
               ) : null}
             </Flex>
           </Flex>

--- a/frontend/src/components/BookDetailCard.tsx
+++ b/frontend/src/components/BookDetailCard.tsx
@@ -80,21 +80,23 @@ const BookDetailView: React.FC<BookDetailViewProps> = ({ book }) => {
         variant="outline"
       >
         <CardHeader>
-          <Flex align="flex-start" flexDirection={{sm: 'column', md: "row"}} justify="space-between" gap="2">
+          <Flex align="flex-start" flexDirection={{base: 'column', lg: "row"}} justify="space-between" gap={{base: "4", lg: "2"}}>
             <Heading as="h3" fontSize={['xl', '2xl', '2xl']} whiteSpace='break-spaces' flexShrink={0} flex={1} minW="0">
               <Text>{title}</Text>
             </Heading>
-            {md5 != undefined && md5.length > 0 ? (
-              <Button as={ExternalLink} minWidth='unset' href={import.meta.env.VITE_MD5_BASE_URL + md5}>
-                {t('table.redirect2aa')}
-              </Button>
-            ) : null}
-            {extension === 'epub' &&
-            ipfs_cid != undefined &&
-            ipfs_cid.length > 0 &&
-            rootContext.ipfsGateways.length > 0 ? (
-              <Button onClick={onOpen}>{t('table.preview')}</Button>
-            ) : null}
+            <Flex gap="2" flexDirection={{base: 'column', sm: "row"}}  w={{base: "100%", sm: 'auto'}}>
+              {md5 != undefined && md5.length > 0 ? (
+                <Button as={ExternalLink} minWidth='unset' w={{base: "100%", sm: 'auto'}} href={import.meta.env.VITE_MD5_BASE_URL + md5}>
+                  {t('table.redirect2aa')}
+                </Button>
+              ) : null}
+              {extension === 'epub' &&
+              ipfs_cid != undefined &&
+              ipfs_cid.length > 0 &&
+              rootContext.ipfsGateways.length > 0 ? (
+                <Button onClick={onOpen} w={{base: "100%", sm: 'auto'}}>{t('table.preview')}</Button>
+              ) : null}
+            </Flex>
           </Flex>
         </CardHeader>
         <Divider />

--- a/frontend/src/components/BookDetailCard.tsx
+++ b/frontend/src/components/BookDetailCard.tsx
@@ -80,12 +80,12 @@ const BookDetailView: React.FC<BookDetailViewProps> = ({ book }) => {
         variant="outline"
       >
         <CardHeader>
-          <Flex align="center" justify="space-between" gap="2">
-            <Heading as="h3" fontSize={['xl', '2xl', '2xl']} flexShrink={0} flex={1} minW="0">
+          <Flex align="flex-start" flexDirection={{sm: 'column', md: "row"}} justify="space-between" gap="2">
+            <Heading as="h3" fontSize={['xl', '2xl', '2xl']} whiteSpace='break-spaces' flexShrink={0} flex={1} minW="0">
               <Text>{title}</Text>
             </Heading>
             {md5 != undefined && md5.length > 0 ? (
-              <Button as={ExternalLink} href={import.meta.env.VITE_MD5_BASE_URL + md5}>
+              <Button as={ExternalLink} minWidth='unset' href={import.meta.env.VITE_MD5_BASE_URL + md5}>
                 {t('table.redirect2aa')}
               </Button>
             ) : null}

--- a/frontend/src/components/DataTable.tsx
+++ b/frontend/src/components/DataTable.tsx
@@ -246,7 +246,7 @@ export default function DataTable<Data extends object>({
                           ? '0'
                           : undefined
                       }
-                      textOverflow="ellipsis"
+                      textOverflow={cell.id.endsWith('title') ? 'ellipsis' : 'hidden'}
                       title={(cell.getValue() as any)?.toString()}
                     >
                       {flexRender(cell.column.columnDef.cell, cell.getContext())}

--- a/frontend/src/components/DataTable.tsx
+++ b/frontend/src/components/DataTable.tsx
@@ -246,7 +246,7 @@ export default function DataTable<Data extends object>({
                           ? '0'
                           : undefined
                       }
-                      textOverflow="hidden"
+                      textOverflow="ellipsis"
                       title={(cell.getValue() as any)?.toString()}
                     >
                       {flexRender(cell.column.columnDef.cell, cell.getContext())}


### PR DESCRIPTION

- feat: add `ellipsis` style when title is too long

| Before      | After |
| ----------- | ----------- |
| <img width="1920" alt="image" src="https://github.com/book-searcher-org/book-searcher/assets/125171539/eca9a86f-aad2-43fb-a50a-e5802b1b274d">      | <img width="1919" alt="image" src="https://github.com/book-searcher-org/book-searcher/assets/125171539/c9a600cc-b42b-421d-b58e-7683b7da4c5d">       |

- fix: responsive styles for detail card title section

| Before      | After |
| ----------- | ----------- |
|<img width="1908" alt="image" src="https://github.com/book-searcher-org/book-searcher/assets/125171539/f29f0b0f-25d5-4b6c-961b-7ebd89cf55d1">| <img width="1920" alt="image" src="https://github.com/book-searcher-org/book-searcher/assets/125171539/f61c22e8-acbb-4241-93ab-b890d2630b3e"> |
|<img width="586" alt="image" src="https://github.com/book-searcher-org/book-searcher/assets/125171539/204848c5-488e-4605-98ef-474e2cdb7bb8"> |  <img width="587" alt="image" src="https://github.com/book-searcher-org/book-searcher/assets/125171539/695428bd-ae3f-4487-a972-707f6f28f084"> |





