### PR TITLE
Downgrade "@tauri-apps/api" version

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,7 @@
     "@tanstack/react-query": "^4.36.1",
     "@tanstack/react-table": "^8.10.7",
     "@tanstack/table-core": "^8.10.7",
-    "@tauri-apps/api": "next",
+    "@tauri-apps/api": "latest",
     "@tauri-apps/plugin-dialog": "latest",
     "@tauri-apps/plugin-shell": "latest",
     "ahooks": "^3.7.8",


### PR DESCRIPTION
Build error: "invoke" is not exported by "node_modules/@tauri-apps/api/index.js", imported by "src/scripts/searcher-tauri.ts".